### PR TITLE
Add support for httpie/curlie to elisp

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ redirect, to inhibit redirection, let-binding `url-max-redirections`, e.g.,
    (url-retrieve-synchronously "http://emacs-china.org")))
 ```
 
+## httpie to elisp
+
+`curl-to-elisp-httpie-to-elisp` uses [curlie](https://curlie.io/) to
+transform an [httpie](https://httpie.org/)/curlie command to elisp.
+
+You need to have `curlie` binary in your path (or customize
+`curl-to-elisp-curlie-binary`).
+
 ## Dependencies
 
 - Emacs 25.1


### PR DESCRIPTION
Hi there, 
I found this package was a useful idea, and thought that maybe we could take a little step further.

By calling `curlie` command, we get a curl equivalent command to an httpie/curlie cli call, which we pass to the curl-to-elisp function. Here's curlie: https://github.com/rs/curlie package

I'm not entirely sure this PR deserves to be merged (it now relies on an external command that has to be found in the path, etc..., as opposed to your clean no-dependencies approach taken till now), but wanted to show it here so you can decide.

The PR is not using the usual shell-command-to-string because that function binds `</dev/null ` at the end of any command, and `curlie` thinks the command is a POST and we're trying to push some data from a file descriptor.  Here's a journal log I wrote while hacking on it, just if you want to know more details. It's a train of thought text, so maybe incoherent at times. https://gist.github.com/97f6302bb7935cb8e1ffcb80b356725e

